### PR TITLE
rename `Distances`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.2-
-Distance
+Distances
 Iterators


### PR DESCRIPTION
see https://github.com/JuliaStats/Distance.jl/issues/25 to remove the warning when `using Gadly`
