### PR TITLE
Fix some NaN problems and a few other fixes.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,12 @@ version = "0.5.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-julia = "0.7, 1"
 Distances = "0.7, 0.8, 0.9, 0.10"
+julia = "0.7, 1"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/kd.jl
+++ b/src/kd.jl
@@ -143,7 +143,7 @@ function build_kdtree(xs::AbstractMatrix{T},
 
     # find the median and partition
     if isodd(length(perm))
-        mid = length(perm) ÷ 2
+        mid = (length(perm) + 1) ÷ 2
         partialsort!(perm, mid, by=i -> xs[i, j])
         med = xs[perm[mid], j]
         mid1 = mid

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,3 +32,24 @@ let x = 1:10, y = sin.(1:10)
 end
 
 @test_throws DimensionMismatch loess([1.0 2.0; 3.0 4.0], [1.0])
+
+@testset "Issue 28" begin
+    @testset "Example 1" begin
+        x = [1.0, 2.0, 3.0, 4.0]
+        y = [1.0, 2.0, 3.0, 4.0]
+        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 1. Try increasing the value of span.") loess(x, y, span = 0.25)
+        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 2. Try increasing the value of span.") loess(x, y, span = 0.33)
+        @test predict(loess(x, y), x) ≈ x
+    end
+
+    @testset "Example 2" begin
+        x = [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]
+        y = [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]
+        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 2. Try increasing the value of span.") loess(x, y, span = 0.33)
+        # For 0.4 and 0.5 these current don't hit the middle values. I suspect
+        # the issue is related to the ties in x.
+        @test_broken predict(loess(x, y, span = 0.4), x) ≈ x
+        @test_broken predict(loess(x, y, span = 0.5), x) ≈ x
+        @test predict(loess(x, y, span = 0.6), x) ≈ x
+    end
+end


### PR DESCRIPTION
Handle prediction at tree split points separately. Always use qr
factorization when solving the local system to avoid error when
the system is singular. Also fix a one-off error in the median
calculation in the KDTree implementation.

This fixes some of the issues mentioned in https://github.com/JuliaStats/Loess.jl/issues/28 though not all
of them. The solution is to error out informatively in some cases
when the local system becomes too small. I think the main remaining
item is to handle ties differently. I expect that we'd have to construct
the tree only based on unique elements but that is for a future PR.
For now, I've added the test cases with ties from #28 but marked
some of them with `@test_broken`.