### PR TITLE
Branch on Julia version to avoid qr deprecation warning

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -102,7 +102,11 @@ function loess(xs::AbstractMatrix{T}, ys::AbstractVector{T};
             vs[i] = ys[pᵢ] * w
         end
 
-        F = qr(us, Val(true))
+        if VERSION < v"1.7.0-DEV.1188"
+            F = qr(us, Val(true))
+        else
+            F = qr(us, ColumnNorm())
+        end
         bs[k,:] = F\vs
     end
 


### PR DESCRIPTION
The old qr invocation will give deprecation warning on Julia 1.7.