### PR TITLE
Fix type stability

### DIFF
--- a/src/kd.jl
+++ b/src/kd.jl
@@ -58,7 +58,7 @@ function KDTree(xs::M,
         push!(verts, T[vert...])
     end
 
-    root = build_kdtree(xs, perm, bounds, leaf_size_cutoff, leaf_diameter_cutoff, verts)
+    root = build_kdtree(xs, perm, bounds, leaf_size_cutoff, convert(T,leaf_diameter_cutoff), verts)
 
     KDTree(xs, collect(1:n), root, verts, bounds)
 end

--- a/src/kd.jl
+++ b/src/kd.jl
@@ -7,12 +7,12 @@ struct KDInternalNode{T <: AbstractFloat}
     rightnode::Union{Nothing, KDInternalNode{T}}
 end
 
-struct KDTree{T <: AbstractFloat}
-    xs::AbstractMatrix{T} # A matrix of n, m-dimensional observations
-    perm::Vector{Int}     # permutation of data to avoid modifying xs
+struct KDTree{T <: AbstractFloat, M <: AbstractMatrix{T}}
+    xs::M                                   # A matrix of n, m-dimensional observations
+    perm::Vector{Int}                       # permutation of data to avoid modifying xs
     root::Union{Nothing, KDInternalNode{T}} # root node
     verts::Set{Vector{T}}
-    bounds::Matrix{T}     # Top-level bounding box
+    bounds::Matrix{T}                       # Top-level bounding box
 end
 
 
@@ -33,9 +33,9 @@ Returns:
   A `KDTree` object
 
 """
-function KDTree(xs::AbstractMatrix{T},
+function KDTree(xs::M,
                 leaf_size_factor=0.05,
-                leaf_diameter_factor=0.0) where T <: AbstractFloat
+                leaf_diameter_factor=0.0) where {T <: AbstractFloat, M <: AbstractMatrix{T}}
 
     n, m = size(xs)
     perm = collect(1:n)
@@ -106,12 +106,12 @@ Modifies:
 Returns:
   Either `nothing` (used as leaf node) or a `KDInternalNode`
 """
-function build_kdtree(xs::AbstractMatrix{T},
+function build_kdtree(xs::M,
                       perm::AbstractArray,
                       bounds::Matrix{T},
                       leaf_size_cutoff::Int,
                       leaf_diameter_cutoff::T,
-                      verts::Set{Vector{T}}) where T
+                      verts::Set{Vector{T}}) where {T <: AbstractFloat, M <: AbstractMatrix{T}}
     n, m = size(xs)
 
     if length(perm) <= leaf_size_cutoff || diameter(bounds) <= leaf_diameter_cutoff
@@ -192,7 +192,7 @@ end
 Traverse the tree `kdtree` to the bottom and return the verticies of
 the bounding hypercube of the leaf node containing the point `x`.
 """
-function traverse(kdtree::KDTree{T}, x::AbstractVector{T}) where T
+function traverse(kdtree::KDTree{T,M}, x::AbstractVector{T}) where {T <: AbstractFloat, M <: AbstractMatrix{T}}
     m = size(kdtree.bounds, 2)
 
     if length(x) != m

--- a/src/kd.jl
+++ b/src/kd.jl
@@ -17,7 +17,7 @@ end
 
 
 """
-    KDTree(xs, leaf_size_factor, leaf_diameter factor)
+    KDTree(xs, leaf_size_factor, leaf_diameter_factor)
 
 Construct a kd-tree
 


### PR DESCRIPTION
Dear developers of Loess,

Thanks for a great package!

This PR is to tackle the type instability issue raised in #51 . In summary, I

- Eliminated abstract fields in structs, using parameters to handle subtypes of a given abstract type.
- Defined `LoessModel` as parametric immutable struct, with an extra boolean parameter that signals an univariate (`false`) or multivariate (`true`) model. This leverages multiple dispatching to easily distinguish between otherwise ambiguous calls like `predict(model,zs)` where `zs` is a vector. Indeed, `zs` could equally correspond to multiple points in a univariate model, or 1 point in multivariate model.
- Replaced `KDLeafNode` with `nothing` since it was an empty struct with no methods associated to it
- Other type-consistency fixes, which in particular fixed #48 . 

As a consequence of the increased type stability, Loess now runs about 20% faster, so this PR indirectly addresses #47 . I benchmarked the functions provided there by @ayushpatnaikgit, obtaining 

```julia
  775.432 μs (28 allocations: 4.94 KiB) <- RCall
  918.587 μs (13455 allocations: 2.97 MiB) <- Loess (master branch)
  723.696 μs (8431 allocations: 2.83 MiB) <- Loess (this branch)
```

The branch passes the (non-broken) tests.

Comments and edits are welcome!

Best,
Miguel
