### PR TITLE
Set max distance to one when it's zero

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -50,9 +50,6 @@ function loess(
 
     n, m = size(xs)
     q = floor(Int, span * n)
-    if q < degree + 1
-        throw(ArgumentError("neighborhood size must be larger than degree+1=$(degree + 1) but was $q. Try increasing the value of span."))
-    end
 
     # TODO: We need to keep track of how we are normalizing so we can
     # correctly apply predict to unnormalized data. We should have a normalize
@@ -90,6 +87,7 @@ function loess(
         # find the q closest points
         partialsort!(perm, 1:q, by=i -> ds[i])
         dmax = maximum([ds[perm[i]] for i = 1:q])
+        dmax = iszero(dmax) ? one(dmax) : dmax
 
         for i in 1:q
             pᵢ = perm[i]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,18 +44,18 @@ end
     @testset "Example 1" begin
         x = [1.0, 2.0, 3.0, 4.0]
         y = [1.0, 2.0, 3.0, 4.0]
-        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 1. Try increasing the value of span.") loess(x, y, span = 0.25)
-        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 1. Try increasing the value of span.") loess(x, y, span = 0.33)
-        @test predict(loess(x, y), x) ≈ x
+        @test predict(loess(x, y, span = 0.25), x) ≈ y
+        @test predict(loess(x, y, span = 0.33), x) ≈ y
+        @test predict(loess(x, y), x) ≈ y
     end
 
     @testset "Example 2" begin
         x = [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]
         y = [1.0, 1.0, 2.0, 3.0, 4.0, 4.0]
-        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 1. Try increasing the value of span.") loess(x, y, span = 0.33)
-        @test_throws ArgumentError("neighborhood size must be larger than degree+1=3 but was 2. Try increasing the value of span.") predict(loess(x, y, span = 0.4), x) ≈ x
-        @test predict(loess(x, y, span = 0.5), x) ≈ x
-        @test predict(loess(x, y, span = 0.6), x) ≈ x
+        @test predict(loess(x, y, span = 0.33), x) ≈ y
+        @test predict(loess(x, y, span = 0.4), x) ≈ y
+        @test predict(loess(x, y, span = 0.5), x) ≈ y
+        @test predict(loess(x, y, span = 0.6), x) ≈ y
     end
 end
 


### PR DESCRIPTION
This avoids a NaN in the tricubic weight calculation and instead
all the observations end up unweighted. This makes all the examples
from issue 28 work.

This PR is based on top of #64 so that one should ideally be merged first.

Closes #28 