### PR TITLE
Various optimizations

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -10,11 +10,11 @@ export loess, predict
 include("kd.jl")
 
 
-struct LoessModel{T <: AbstractFloat, N <: KDNode}
+struct LoessModel{T <: AbstractFloat}
     xs::Matrix{T} # An n by m predictor matrix containing n observations from m predictors
     ys::Vector{T} # A length n response vector
     predictions_and_gradients::Dict{Vector{T}, Vector{T}} # kd-tree vertexes mapped to prediction and gradient at each vertex
-    kdtree::KDTree{T, N}
+    kdtree::KDTree{T}
 end
 
 """


### PR DESCRIPTION
This avoids a lot of dynamic dispatch by removing abstract type in the fields by making `KDInternalNode` and `KDTree` parametric on the node types and by avoiding `AbstractArray` as fields. At least for now, it should be fine to require `Matrix` and `Vector` either directly of via conversion. Some timings.

### Current:
```julia
julia> @btime loess($(df.Speed), $(df.Dist));
  87.375 μs (2441 allocations: 847.36 KiB)

julia> @btime predict($ft, 5:25);
  27.834 μs (811 allocations: 31.22 KiB)
```
### New:
```julia
julia> @btime loess($(df.Speed), $(df.Dist));
  77.167 μs (1886 allocations: 813.06 KiB)

julia> @btime predict($ft, 5:25);
  1.986 μs (55 allocations: 4.06 KiB)
```

It might still be possible to improve the speed a bit. E.g. some of the nested loops are in the wrong order but profiling suggests that most of the time in `loess` is spent within `qr` and for `predict` it's spent on allocating the arrays for storing the results so there shouldn't be that much performance left on the table.

Closes #47 and #51. Supersedes #53

Update: to avoid the extra type parameters, I've changed the representation of the tree to use `Union{Nothing,KDNode}` (where `KDNode` is the new name for `KDInternalNode`.) The performance is the same as before.