### PR TITLE
fix calls to constructor

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -136,7 +136,7 @@ function loess(
         ]
     end
 
-    LoessModel(xs, ys, predictions_and_gradients, kdtree)
+    LoessModel(convert(Matrix{T}, xs), convert(Vector{T}, ys), predictions_and_gradients, kdtree)
 end
 
 loess(xs::AbstractVector{T}, ys::AbstractVector{T}; kwargs...) where {T<:AbstractFloat} =

--- a/src/kd.jl
+++ b/src/kd.jl
@@ -65,7 +65,7 @@ function KDTree(
 
     root = build_kdtree(xs, perm, bounds, leaf_size_cutoff, leaf_diameter_cutoff, verts)
 
-    KDTree(xs, collect(1:n), root, verts, bounds)
+    KDTree(convert(Matrix{T}, xs), collect(1:n), root, verts, bounds)
 end
 
 
@@ -276,4 +276,3 @@ function _traverse!(bounds, node::KDNode, x)
         return _traverse!(bounds, node.rightnode, x)
     end
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,12 @@ using RDatasets
     @test Loess.predict(model,x) ≈ y
 end
 
+@testset "reshaped views" begin
+    # See: https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/462
+    # and: https://github.com/JuliaStats/Loess.jl/pull/70
+    @test Loess.loess(reshape(view(rand(4), 1:4), (4, 1)), rand(4)) isa Loess.LoessModel
+end
+
 @testset "sine" begin
     x = 1:10
     y = sin.(1:10)


### PR DESCRIPTION
KDTree and LoessModel only accept concrete matrices, while `loess` and `KDTree` accept abstract matrices.
This PR makes sure to convert before calling the inner `KDTree / LoessModel constructor.
Fixes: https://github.com/MakieOrg/AlgebraOfGraphics.jl/pull/462
I'm not 100% sure why the converts are needed, since Julia usually does call `convert(FieldType, field)` and it seems to work fine for certain abstractmatrices, but fails for e.g.:
```julia
Loess.loess(reshape(view(rand(4), 1:4), (4, 1)), rand(4))
```