### PR TITLE
Use cholesky decomposition whenever possible

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -123,12 +123,16 @@ function loess(
             end
         end
 
-        if VERSION < v"1.7.0-DEV.1188"
-            F = qr(us, Val(true))
+        if isposdef(us' * us)
+            coefs = cholesky(us' * us) \ (us' * vs)
         else
-            F = qr(us, ColumnNorm())
+            if VERSION < v"1.7.0-DEV.1188"
+                F = qr(us, Val(true))
+            else
+                F = qr(us, ColumnNorm())
+            end
+            coefs = F\vs
         end
-        coefs = F\vs
 
         predictions_and_gradients[vert] = [
             us[1, :]' * coefs; # the prediction

--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -122,10 +122,10 @@ function loess(
                 xl *= x
             end
         end
-
+        
         coefs = Matrix{Real}(undef, size(us, 2), 1)
         try
-            coefs = cholesky(us * us') \ (us' * vs)
+            coefs = cholesky(us' * us) \ (us' * vs)
         catch PosDefException
             if VERSION < v"1.7.0-DEV.1188"
                 F = qr(us, Val(true))

--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -123,15 +123,16 @@ function loess(
             end
         end
 
-        if isposdef(us' * us)
-            coefs = cholesky(us' * us) \ (us' * vs)
-        else
+        coefs = Matrix{Real}(undef, size(us, 2), 1)
+        try
+            coefs = cholesky(us * us') \ (us' * vs)
+        catch PosDefException
             if VERSION < v"1.7.0-DEV.1188"
                 F = qr(us, Val(true))
             else
                 F = qr(us, ColumnNorm())
             end
-            coefs = F\vs
+            coefs = F \ vs
         end
 
         predictions_and_gradients[vert] = [


### PR DESCRIPTION
Loess involves doing weighted least squares many times (at each vertex). The original implementation in Netlib, and the one in this package, use QR decomposition for this purpose.  
```julia
if VERSION < v"1.7.0-DEV.1188"
    F = qr(us, Val(true))
else
    F = qr(us, ColumnNorm())
end
coefs = F\vs
```
This is the most expensive part of loess. 

I propose using Cholesky factorization instead of QR decomposition. 
```julia
coefs = cholesky(us' * us) \ (us' * vs)
```
The idea is that `us' * us` and `us' * vs` are pretty small.  

Unfortunately, cholesky factorization fails when the matrix being factorized is not positive definite. Hence, I suggest using QR decomposition as a backup using an if condition. Try and catch also work, but I don't like using them. 

Using my proposed method will lead to modest gains in computation time, but noticeable improvement in memory allocations. The numerical differences will between the two methods will be small. I did some tests (based on the example in the README) and the differences are < e-10. I think that's reasonable, given loess is an approximation. 

Here's the performance comparison on the example in the [README](https://github.com/JuliaStats/Loess.jl#synopsis). 

```julia
using BenchmarkTools, Loess
xs = 10 .* rand(100)
ys = sin.(xs) .+ 0.5 * rand(100)
```

Current implementation: 
 ```
@btime loess(xs, ys, span=0.5)
164.083 μs (3573 allocations: 1.26 MiB)
```

Proposed:
```
@btime loess(xs, ys, span=0.5)
 140.478 μs (3080 allocations: 102.70 KiB)
```

As far as I know, this trick hasn't been tried before in the context of loess. While all the test cases pass (on Julia 1.9.0), we could be missing out on something. I've had several discussions on this with @ViralBShah and @mousum-github. Instead of opening an issue to discuss it further, I just did the PR, since it's a tiny change in terms of the number of lines. 