### PR TITLE
Add let block around call to partialsort! to avoid overhead from  captured variable

### DIFF
--- a/src/kd.jl
+++ b/src/kd.jl
@@ -88,7 +88,6 @@ function diameter(bounds::Matrix)
     euclidean(vec(bounds[1,:]), vec(bounds[2,:]))
 end
 
-
 """
     build_kdtree(xs, perm, bounds, leaf_size_cutoff, leaf_diameter_cutoff, verts)
 
@@ -185,7 +184,11 @@ function build_kdtree(xs::AbstractMatrix{T},
             offset = -offset + (offset <= 0)
             continue
         end
-        p12 = partialsort!(perm, mid1:mid2, by = i -> xs[i, j])
+        # Use a let block to avoid overhead from captured variable in closure
+        # Ref https://github.com/JuliaLang/julia/issues/15276
+        p12 = let j = j
+            partialsort!(perm, mid1:mid2, by = i -> xs[i, j])
+        end
         if xs[p12[1], j] == xs[p12[2], j]
             @debug "tie! Adjusting offset" xs[p12[1], j] xs[p12[2], j] offset
             # This makes the offset 0, 1, -1, 2, -2, ...


### PR DESCRIPTION
See https://github.com/JuliaStats/Loess.jl/issues/73#issuecomment-1676438282 for some details. This isn't sufficient to make `loess` feasible for the dataset in #73 but it significantly speeds up the calculation. For a random subset with 10000 elements of the dataset from #73, I'm getting
```julia
julia> ft = @time loess(x, y);
  7.355545 seconds (357.20 M allocations: 5.519 GiB, 5.16% gc time)
```
with the current implementation and
```julia
julia> ft = @time loess(x, y);
  0.208809 seconds (10.97 k allocations: 200.746 MiB, 5.05% gc time)
```
with this PR.

Update: I've changed this to just use a `let` block instead the helper function. The performance impact is the same.