### PR TITLE
Scale rank-determination threshold by largest singular value

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -124,8 +124,9 @@ function _loess(
         Fact = svd(us)
 
         # compute the inverse of the singular values with thresholding similar
-        # to pinv
-        Sinv = map!(t -> t > eps(one(t)) * q ? inv(t) : zero(t), Fact.S, Fact.S)
+        # to pinv (relative to the largest singular value)
+        S₁ = first(Fact.S)
+        Sinv = map!(t -> t > eps(one(t)) * q * S₁ ? inv(t) : zero(t), Fact.S, Fact.S)
         # Compute S⁻¹ * Uᵗ * W in place
         Fact.U .*= view(us, :, 1) .* Sinv'
         # Finalize the pseudo inverse


### PR DESCRIPTION
## Summary

The custom pseudo-inverse introduced in 26b3b648 ("Some memory optimizations", part of #104) inlined what used to be `Fact \ vs` and `Fact \ Diagonal(us[:, 1])`. In doing so the threshold lost its `* S[1]` factor:

```julia
# stdlib LinearAlgebra ldiv!(::SVD, B) — the previous behavior
k = searchsortedlast(A.S, eps(real(T)) * A.S[1], rev=true)
```

vs. what landed:

```julia
Sinv = map!(t -> t > eps(one(t)) * q ? inv(t) : zero(t), Fact.S, Fact.S)
```

This made rank determination scale-dependent: a singular value of, say, `1e-6` was treated as nonzero whether `S[1]` was `1` or `1e8`. This PR restores the relative-to-`S[1]` threshold (keeping the `q` factor, which acts like the `max(m,n)` factor in `pinv`'s convention):

```julia
S₁ = first(Fact.S)
Sinv = map!(t -> t > eps(one(t)) * q * S₁ ? inv(t) : zero(t), Fact.S, Fact.S)
```

`S₁` is captured before the in-place `map!` overwrites `Fact.S[1]`.

## Test plan

- [x] `Pkg.test()` passes
- [x] Sanity-checked AOG #760 case (n=7, span=0.75): predictions and `s` unchanged, since the smallest local singular value (~0.49) is well above either threshold