### PR TITLE
Support StatsFuns@2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Loess"
 uuid = "4345ca2d-374a-55d4-8d30-97f9976e7612"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -14,7 +14,7 @@ Distances = "0.7, 0.8, 0.9, 0.10"
 LinearAlgebra = "1"
 Statistics = "1"
 StatsAPI = "1.1"
-StatsFuns = "1"
+StatsFuns = "1, 2"
 julia = "1.8"
 
 [extras]


### PR DESCRIPTION
Loess only uses `StatsFuns.tdistinvcdf` which is not affected by the update.